### PR TITLE
Add initial backend and Flutter scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Node
+node_modules/
+dist/
+.env
+
+# Flutter
+.dart_tool/
+build/
+ios/
+android/
+.env

--- a/german_vocab_app/.env.example
+++ b/german_vocab_app/.env.example
@@ -1,0 +1,1 @@
+API_BASE=http://localhost:3000

--- a/german_vocab_app/lib/main.dart
+++ b/german_vocab_app/lib/main.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'screens/add_word_page.dart';
+import 'screens/card_list_page.dart';
+
+Future<void> main() async {
+  await dotenv.load();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'German Vocab',
+      routes: {
+        '/': (_) => const CardListPage(),
+        '/add': (_) => const AddWordPage(),
+      },
+    );
+  }
+}

--- a/german_vocab_app/lib/models/card.dart
+++ b/german_vocab_app/lib/models/card.dart
@@ -1,0 +1,28 @@
+class VocabCard {
+  final int id;
+  final String germanWord;
+  final String englishTranslation;
+  final String usageExample;
+  final String imageBase64;
+  final String audioBase64;
+
+  VocabCard({
+    required this.id,
+    required this.germanWord,
+    required this.englishTranslation,
+    required this.usageExample,
+    required this.imageBase64,
+    required this.audioBase64,
+  });
+
+  factory VocabCard.fromJson(Map<String, dynamic> json) {
+    return VocabCard(
+      id: json['id'] as int,
+      germanWord: json['german_word'] as String,
+      englishTranslation: json['english_translation'] as String,
+      usageExample: json['usage_example'] as String,
+      imageBase64: json['image_base64'] as String,
+      audioBase64: json['audio_base64'] as String,
+    );
+  }
+}

--- a/german_vocab_app/lib/screens/add_word_page.dart
+++ b/german_vocab_app/lib/screens/add_word_page.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+class AddWordPage extends StatefulWidget {
+  const AddWordPage({super.key});
+
+  @override
+  State<AddWordPage> createState() => _AddWordPageState();
+}
+
+class _AddWordPageState extends State<AddWordPage> {
+  final _controller = TextEditingController();
+  bool _loading = false;
+
+  Future<void> _submit() async {
+    final word = _controller.text.trim();
+    if (word.isEmpty) return;
+    setState(() => _loading = true);
+    await http.post(
+      Uri.parse('${dotenv.env['API_BASE']}/cards'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'german_word': word}),
+    );
+    setState(() => _loading = false);
+    if (mounted) Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Word')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(controller: _controller),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _loading ? null : _submit,
+              child: const Text('Generate'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/german_vocab_app/lib/screens/card_list_page.dart
+++ b/german_vocab_app/lib/screens/card_list_page.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+import '../models/card.dart';
+
+class CardListPage extends StatefulWidget {
+  const CardListPage({super.key});
+
+  @override
+  State<CardListPage> createState() => _CardListPageState();
+}
+
+class _CardListPageState extends State<CardListPage> {
+  List<VocabCard> cards = [];
+
+  Future<void> _fetch() async {
+    final res = await http.get(Uri.parse('${dotenv.env['API_BASE']}/cards'));
+    final data = jsonDecode(res.body) as List;
+    setState(() {
+      cards = data.map((e) => VocabCard.fromJson(e)).toList();
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cards'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () => Navigator.pushNamed(context, '/add').then((_) => _fetch()),
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: cards.length,
+        itemBuilder: (ctx, i) {
+          final c = cards[i];
+          return ListTile(
+            leading: Image.memory(base64Decode(c.imageBase64)),
+            title: Text('${c.germanWord} → ${c.englishTranslation}'),
+            subtitle: Text(c.usageExample),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/german_vocab_app/pubspec.yaml
+++ b/german_vocab_app/pubspec.yaml
@@ -1,0 +1,19 @@
+name: german_vocab_app
+description: A Flutter app for vocab cards
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.0.0
+  flutter_dotenv: ^0.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/vocab-backend/.env.example
+++ b/vocab-backend/.env.example
@@ -1,0 +1,5 @@
+OPENAI_API_KEY=your_openai_key
+PGHOST=localhost
+PGUSER=user
+PGPASSWORD=password
+PGDATABASE=vocab

--- a/vocab-backend/package.json
+++ b/vocab-backend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "vocab-backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/app.js",
+  "scripts": {
+    "dev": "nodemon src/app.ts",
+    "build": "tsc",
+    "start": "node dist/app.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "cors": "^0.0.0",
+    "dotenv": "^0.0.0",
+    "express": "^0.0.0",
+    "multer": "^0.0.0",
+    "openai": "^0.0.0",
+    "pg": "^0.0.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^0.0.0",
+    "@types/express": "^0.0.0",
+    "@types/multer": "^0.0.0",
+    "@types/node": "^0.0.0",
+    "@types/pg": "^0.0.0",
+    "nodemon": "^0.0.0",
+    "ts-node": "^0.0.0",
+    "typescript": "^0.0.0"
+  },
+  "type": "module"
+}

--- a/vocab-backend/src/app.ts
+++ b/vocab-backend/src/app.ts
@@ -1,0 +1,17 @@
+import express from "express";
+import cors from "cors";
+import dotenv from "dotenv";
+import cardsRouter from "./routes/cards";
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use("/cards", cardsRouter);
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on ${port}`);
+});

--- a/vocab-backend/src/db.ts
+++ b/vocab-backend/src/db.ts
@@ -1,0 +1,11 @@
+import { Pool } from "pg";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+export const pool = new Pool({
+  host: process.env.PGHOST,
+  user: process.env.PGUSER,
+  password: process.env.PGPASSWORD,
+  database: process.env.PGDATABASE,
+});

--- a/vocab-backend/src/routes/cards.ts
+++ b/vocab-backend/src/routes/cards.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { generateCardParts } from "../services/openai";
+import { pool } from "../db";
+
+const router = Router();
+
+router.post("/", async (req, res) => {
+  const { german_word } = req.body;
+  const parts = await generateCardParts(german_word);
+  const { rows } = await pool.query(
+    `INSERT INTO cards (german_word, english_translation, usage_example, image_base64, audio_base64)
+     VALUES ($1,$2,$3,$4,$5) RETURNING *`,
+    [german_word, parts.translation, parts.usage, parts.imageBase64, parts.audioBase64]
+  );
+  res.json(rows[0]);
+});
+
+router.get("/", async (_req, res) => {
+  const { rows } = await pool.query("SELECT * FROM cards ORDER BY created_at DESC");
+  res.json(rows);
+});
+
+export default router;

--- a/vocab-backend/src/services/openai.ts
+++ b/vocab-backend/src/services/openai.ts
@@ -1,0 +1,36 @@
+import OpenAI from "openai";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+export async function generateCardParts(word: string) {
+  const gpt = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: "You are a translator." },
+      { role: "user", content: `Word: ${word}` },
+    ],
+  });
+  const [translation, usage] = gpt.choices[0].message.content!.split("\n");
+
+  const img = await openai.images.generate({
+    model: "gpt-image-1",
+    prompt: `Illustration of '${word}'`,
+    size: "512x512",
+  });
+
+  const audio = await openai.audio.speech.create({
+    model: "gpt-4o-mini-tts",
+    voice: "alloy",
+    input: word,
+  });
+
+  return {
+    translation,
+    usage,
+    imageBase64: img.data[0].b64_json,
+    audioBase64: audio.data[0].b64_json,
+  };
+}

--- a/vocab-backend/src/types.ts
+++ b/vocab-backend/src/types.ts
@@ -1,0 +1,9 @@
+export interface Card {
+  id: number;
+  german_word: string;
+  english_translation: string;
+  usage_example: string;
+  image_base64: string;
+  audio_base64: string;
+  created_at: string;
+}

--- a/vocab-backend/tsconfig.json
+++ b/vocab-backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Node/Express backend with OpenAI card generation service and PostgreSQL connection
- add Flutter client with screens to add words and list cards
- include example environment files for backend and client

## Testing
- `npm test`
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab0a0bd31c8332b992d61efe6accb7